### PR TITLE
Tighten CORS and environment-specific API security settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,12 @@ Create a `.env` file with:
 
 ~~~env
 OPENAI_API_KEY=your_api_key_here
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+REACT_APP_SERVER_URL=http://localhost:10000
+REACT_APP_PROD_SERVER_URL=https://your-production-api.example.com
 ~~~
+
+`CORS_ALLOWED_ORIGINS` accepts a comma-separated list. In development, the server falls back to `http://localhost:3000` and `http://127.0.0.1:3000` when the variable is omitted. In production, you should set it explicitly so browser requests are only accepted from trusted frontends.
 
 ---
 

--- a/server/app.js
+++ b/server/app.js
@@ -17,15 +17,12 @@ const {
   getGuidance,
   normalizeGuidance,
 } = require("./services/aiService");
+const { createCorsOptions } = require("./config/security");
 
 const app = express();
 const GUEST_AI_REQUEST_LIMIT = 3;
-
 const isDev = process.env.NODE_ENV === "development";
-const corsOptions = {
-  origin: isDev ? true : "*",
-  optionsSuccessStatus: 201,
-};
+const corsOptions = createCorsOptions();
 
 const routePaths = (path) => [path, `/api${path}`];
 

--- a/server/config/security.js
+++ b/server/config/security.js
@@ -1,0 +1,53 @@
+const DEFAULT_DEVELOPMENT_ORIGINS = [
+  "http://localhost:3000",
+  "http://127.0.0.1:3000",
+];
+
+const parseAllowedOrigins = (value) => {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+};
+
+const getAllowedOrigins = ({
+  nodeEnv = process.env.NODE_ENV,
+  allowedOrigins = process.env.CORS_ALLOWED_ORIGINS,
+} = {}) => {
+  const configuredOrigins = parseAllowedOrigins(allowedOrigins);
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  return nodeEnv === "development" ? DEFAULT_DEVELOPMENT_ORIGINS : [];
+};
+
+const createCorsOriginHandler = (allowedOrigins) => (origin, callback) => {
+  if (!origin || allowedOrigins.includes(origin)) {
+    callback(null, true);
+    return;
+  }
+
+  callback(new Error("Not allowed by CORS"));
+};
+
+const createCorsOptions = (options = {}) => {
+  const allowedOrigins = getAllowedOrigins(options);
+
+  return {
+    origin: createCorsOriginHandler(allowedOrigins),
+    optionsSuccessStatus: 200,
+  };
+};
+
+module.exports = {
+  DEFAULT_DEVELOPMENT_ORIGINS,
+  createCorsOptions,
+  getAllowedOrigins,
+  parseAllowedOrigins,
+};

--- a/server/config/security.js
+++ b/server/config/security.js
@@ -3,6 +3,8 @@ const DEFAULT_DEVELOPMENT_ORIGINS = [
   "http://127.0.0.1:3000",
 ];
 
+const normalizeOrigin = (origin) => origin.replace(/\/+$/, "");
+
 const parseAllowedOrigins = (value) => {
   if (typeof value !== "string") {
     return [];
@@ -10,7 +12,7 @@ const parseAllowedOrigins = (value) => {
 
   return value
     .split(",")
-    .map((origin) => origin.trim())
+    .map((origin) => normalizeOrigin(origin.trim()))
     .filter(Boolean);
 };
 
@@ -19,12 +21,13 @@ const getAllowedOrigins = ({
   allowedOrigins = process.env.CORS_ALLOWED_ORIGINS,
 } = {}) => {
   const configuredOrigins = parseAllowedOrigins(allowedOrigins);
+  const runtimeEnvironment = nodeEnv || "development";
 
   if (configuredOrigins.length > 0) {
     return configuredOrigins;
   }
 
-  return nodeEnv === "development" ? DEFAULT_DEVELOPMENT_ORIGINS : [];
+  return runtimeEnvironment === "development" ? DEFAULT_DEVELOPMENT_ORIGINS : [];
 };
 
 const createCorsOriginHandler = (allowedOrigins) => (origin, callback) => {

--- a/server/config/security.js
+++ b/server/config/security.js
@@ -31,12 +31,19 @@ const getAllowedOrigins = ({
 };
 
 const createCorsOriginHandler = (allowedOrigins) => (origin, callback) => {
-  if (!origin || allowedOrigins.includes(origin)) {
+  if (!origin) {
     callback(null, true);
     return;
   }
 
-  callback(new Error("Not allowed by CORS"));
+  const normalizedOrigin = normalizeOrigin(origin);
+
+  if (allowedOrigins.includes(normalizedOrigin)) {
+    callback(null, true);
+    return;
+  }
+
+  callback(null, false);
 };
 
 const createCorsOptions = (options = {}) => {

--- a/server/config/security.test.js
+++ b/server/config/security.test.js
@@ -8,7 +8,7 @@ const {
 describe("security config", () => {
   it("parses comma-separated origins", () => {
     expect(
-      parseAllowedOrigins(" https://app.example.com, http://localhost:3000 , ")
+      parseAllowedOrigins(" https://app.example.com/, http://localhost:3000/ , ")
     ).toEqual(["https://app.example.com", "http://localhost:3000"]);
   });
 
@@ -20,6 +20,17 @@ describe("security config", () => {
 
   it("requires explicit origins outside development", () => {
     expect(getAllowedOrigins({ nodeEnv: "production" })).toEqual([]);
+  });
+
+  it("defaults to development origins when nodeEnv is unset", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+
+    try {
+      expect(getAllowedOrigins()).toEqual(DEFAULT_DEVELOPMENT_ORIGINS);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it("prefers configured origins over defaults", () => {

--- a/server/config/security.test.js
+++ b/server/config/security.test.js
@@ -72,7 +72,18 @@ describe("security config", () => {
 
     corsOptions.origin("https://evil.example.com", callback);
 
-    expect(callback.mock.calls[0][0]).toEqual(expect.any(Error));
-    expect(callback.mock.calls[0][0].message).toBe("Not allowed by CORS");
+    expect(callback).toHaveBeenCalledWith(null, false);
+  });
+
+  it("allows requests from approved origins with a trailing slash", () => {
+    const callback = jest.fn();
+    const corsOptions = createCorsOptions({
+      nodeEnv: "production",
+      allowedOrigins: "https://app.example.com",
+    });
+
+    corsOptions.origin("https://app.example.com/", callback);
+
+    expect(callback).toHaveBeenCalledWith(null, true);
   });
 });

--- a/server/config/security.test.js
+++ b/server/config/security.test.js
@@ -1,0 +1,67 @@
+const {
+  DEFAULT_DEVELOPMENT_ORIGINS,
+  createCorsOptions,
+  getAllowedOrigins,
+  parseAllowedOrigins,
+} = require("./security");
+
+describe("security config", () => {
+  it("parses comma-separated origins", () => {
+    expect(
+      parseAllowedOrigins(" https://app.example.com, http://localhost:3000 , ")
+    ).toEqual(["https://app.example.com", "http://localhost:3000"]);
+  });
+
+  it("uses local frontend origins by default in development", () => {
+    expect(getAllowedOrigins({ nodeEnv: "development" })).toEqual(
+      DEFAULT_DEVELOPMENT_ORIGINS
+    );
+  });
+
+  it("requires explicit origins outside development", () => {
+    expect(getAllowedOrigins({ nodeEnv: "production" })).toEqual([]);
+  });
+
+  it("prefers configured origins over defaults", () => {
+    expect(
+      getAllowedOrigins({
+        nodeEnv: "development",
+        allowedOrigins: "https://app.example.com,https://admin.example.com",
+      })
+    ).toEqual(["https://app.example.com", "https://admin.example.com"]);
+  });
+
+  it("allows requests with approved origins", () => {
+    const callback = jest.fn();
+    const corsOptions = createCorsOptions({
+      nodeEnv: "production",
+      allowedOrigins: "https://app.example.com",
+    });
+
+    corsOptions.origin("https://app.example.com", callback);
+
+    expect(callback).toHaveBeenCalledWith(null, true);
+  });
+
+  it("allows requests without an origin header", () => {
+    const callback = jest.fn();
+    const corsOptions = createCorsOptions({ nodeEnv: "production" });
+
+    corsOptions.origin(undefined, callback);
+
+    expect(callback).toHaveBeenCalledWith(null, true);
+  });
+
+  it("rejects requests from unapproved origins", () => {
+    const callback = jest.fn();
+    const corsOptions = createCorsOptions({
+      nodeEnv: "production",
+      allowedOrigins: "https://app.example.com",
+    });
+
+    corsOptions.origin("https://evil.example.com", callback);
+
+    expect(callback.mock.calls[0][0]).toEqual(expect.any(Error));
+    expect(callback.mock.calls[0][0].message).toBe("Not allowed by CORS");
+  });
+});


### PR DESCRIPTION
- [x] Normalize incoming `origin` in `createCorsOriginHandler` before `includes` check
- [x] Use `callback(null, false)` instead of `callback(new Error(...))` for disallowed origins
- [x] Add trailing-slash unit test; update rejection test expectation
- [x] All 9 tests passing